### PR TITLE
Support for moves command

### DIFF
--- a/character.go
+++ b/character.go
@@ -36,12 +36,12 @@ func newCharacter(name string, endpoint string, bot *Bot) *Character {
 		endpoint: endpoint,
 		logger:   log.New(os.Stdout, "log: ", log.Lshortfile),
 	}
-	character.frames = SetFrames(character)
+	character.frames = SetFrames(character, bot)
 	return character
 }
 
-func SetFrames(character *Character) map[string]FrameDatum {
-	uri := "http://localhost:8080/usf4/" + character.name
+func SetFrames(character *Character, bot *Bot) map[string]FrameDatum {
+	uri := *bot.service.host + "/" + *bot.service.title + "/" + character.name
 
 	character.Log("Fetching frames for " + character.name)
 	resp, err := http.Get(uri)
@@ -102,5 +102,5 @@ func SetFrames(character *Character) map[string]FrameDatum {
 
 func (character *Character) PrintFormattedDatum(name string) string {
 	frameDatum := character.frames[name]
-	return "startup: " + frameDatum.s + ", active: " + frameDatum.a + ", recovery: " + frameDatum.r + ", adv. on hit: " + frameDatum.ha + ", adv. on block: " + frameDatum.ba
+	return "[" + character.name + ":" + name + "] - " + "startup: " + frameDatum.s + ", active: " + frameDatum.a + ", recovery: " + frameDatum.r + ", hit adv: " + frameDatum.ha + ", block adv: " + frameDatum.ba
 }

--- a/character.go
+++ b/character.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Character struct {
-	name     string
-	endpoint string
-	frames   map[string]FrameDatum
-	logger   *log.Logger
+	name        string
+	endpoint    string
+	frames      map[string]FrameDatum
+	movelistUrl string
+	logger      *log.Logger
 }
 
 type FrameDatum struct {
@@ -36,19 +37,19 @@ func newCharacter(name string, endpoint string, bot *Bot) *Character {
 		endpoint: endpoint,
 		logger:   log.New(os.Stdout, "log: ", log.Lshortfile),
 	}
-	character.frames = SetFrames(character, bot)
+	SetData(character, bot)
 	return character
 }
 
-func SetFrames(character *Character, bot *Bot) map[string]FrameDatum {
+func SetData(character *Character, bot *Bot) {
 	uri := *bot.service.host + "/" + *bot.service.title + "/" + character.name
 
-	character.Log("Fetching frames for " + character.name)
+	character.Log("Fetching data for " + character.name)
 	resp, err := http.Get(uri)
 
 	if err != nil {
 		// handle error here
-		character.Log("Failed to get frame data for " + character.name)
+		character.Log("Failed to get data for " + character.name)
 	}
 
 	defer resp.Body.Close()
@@ -92,15 +93,20 @@ func SetFrames(character *Character, bot *Bot) map[string]FrameDatum {
 				}
 			}
 			frameDatums[k] = fd
+		case string:
+			character.movelistUrl = vv
 		default:
 			character.Log("Unable to read JSON data")
 		}
 	}
-
-	return frameDatums
+	character.frames = frameDatums
 }
 
 func (character *Character) PrintFormattedDatum(name string) string {
 	frameDatum := character.frames[name]
 	return "[" + character.name + ":" + name + "] - " + "startup: " + frameDatum.s + ", active: " + frameDatum.a + ", recovery: " + frameDatum.r + ", hit adv: " + frameDatum.ha + ", block adv: " + frameDatum.ba
+}
+
+func (character *Character) PrintFormattedMoveList() string {
+	return "[" + character.name + "] - " + character.movelistUrl
 }

--- a/fgframebot.go
+++ b/fgframebot.go
@@ -93,20 +93,20 @@ func (bot *Bot) Message(message string) {
 
 func main() {
 	var (
-		channel = flag.String("channel", "#fgframebot", "Channel bot will join")
-		nick    = flag.String("nick", "fgframebot", "Nickname in channel")
-		apiUri  = flag.String("api", "http://localhost:8080", "Define service that responds with frame data")
-		title   = flag.String("title", "usf4", "Define title to scope frame data")
+		channel  = flag.String("channel", "#fgframebot", "Channel bot will join")
+		nick     = flag.String("nick", "fgframebot", "Nickname in channel")
+		apiUri   = flag.String("api", "http://localhost:8080", "Define service that responds with frame data")
+		title    = flag.String("title", "usf4", "Define title to scope frame data")
+		passPath = flag.String("botpass", "bot_pass.txt", "Path to Twitch OAuth password file")
 	)
+	flag.Parse()
 
-	filePass, err := ioutil.ReadFile("bot_pass.txt")
+	filePass, err := ioutil.ReadFile(*passPath)
 	if err != nil {
 		fmt.Println("Unable to read bot_pass.txt file")
 		os.Exit(1)
 	}
 	pass := strings.Replace(string(filePass), "\n", "", 0)
-	flag.Parse()
-
 	bot := NewBot(channel, nick, &pass, apiUri, title)
 	bot.Log("Initialized fgframebot.go")
 	bot.Log("Using API endpoint: " + *bot.service.host + "/" + *bot.service.title)

--- a/fgframebot.go
+++ b/fgframebot.go
@@ -14,6 +14,11 @@ import (
 	"time"
 )
 
+type FrameService struct {
+	host  *string
+	title *string
+}
+
 type Bot struct {
 	conn    net.Conn
 	host    string
@@ -23,10 +28,11 @@ type Bot struct {
 	pass    string
 	logger  *log.Logger
 	timeout int
+	service *FrameService
 }
 
 // TODO: make this use the config file + cmd line args
-func NewBot(channel *string, nick *string, pass *string) *Bot {
+func NewBot(channel *string, nick *string, pass *string, host *string, title *string) *Bot {
 	return &Bot{
 		conn:    nil,
 		host:    "irc.twitch.tv",
@@ -36,6 +42,7 @@ func NewBot(channel *string, nick *string, pass *string) *Bot {
 		pass:    *pass,
 		logger:  log.New(os.Stdout, "log: ", log.Lshortfile),
 		timeout: 60,
+		service: &FrameService{host: host, title: title},
 	}
 }
 
@@ -85,8 +92,12 @@ func (bot *Bot) Message(message string) {
 }
 
 func main() {
-	channel := flag.String("channel", "#fgframebot", "Channel bot will join")
-	nick := flag.String("nick", "fgframebot", "Nickname in channel")
+	var (
+		channel = flag.String("channel", "#fgframebot", "Channel bot will join")
+		nick    = flag.String("nick", "fgframebot", "Nickname in channel")
+		apiUri  = flag.String("api", "http://localhost:8080", "Define service that responds with frame data")
+		title   = flag.String("title", "usf4", "Define title to scope frame data")
+	)
 
 	filePass, err := ioutil.ReadFile("bot_pass.txt")
 	if err != nil {
@@ -96,8 +107,9 @@ func main() {
 	pass := strings.Replace(string(filePass), "\n", "", 0)
 	flag.Parse()
 
-	bot := NewBot(channel, nick, &pass)
+	bot := NewBot(channel, nick, &pass, apiUri, title)
 	bot.Log("Initialized fgframebot.go")
+	bot.Log("Using API endpoint: " + *bot.service.host + "/" + *bot.service.title)
 	bot.Connect()
 	bot.JoinChannel()
 

--- a/fgframes_api.go
+++ b/fgframes_api.go
@@ -30,8 +30,10 @@ func (bot *Bot) ReadCmd(userName string, userMessage string) {
 
 		characterName := strings.ToLower(strings.TrimSpace(data[0]))
 		characterMove := strings.ToLower(strings.TrimSpace(data[1]))
+
 		character := newCharacter(characterName, apiConfig.endpoint, bot)
 		message := character.PrintFormattedDatum(characterMove)
+
 		bot.Message(message)
 
 	} else if strings.Contains(userMessage, "!characters") {
@@ -44,7 +46,10 @@ func (bot *Bot) ReadCmd(userName string, userMessage string) {
 }
 
 func GetCharacters(bot *Bot) string {
-	uri := "http://localhost:8080/usf4/characters"
+	uri := *bot.service.host + "/" + *bot.service.title + "/" + "characters"
+
+	bot.Log("Fetching characters from " + uri)
+
 	resp, err := http.Get(uri)
 
 	if err != nil {

--- a/fgframes_api.go
+++ b/fgframes_api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -39,6 +40,17 @@ func (bot *Bot) ReadCmd(userName string, userMessage string) {
 	} else if strings.Contains(userMessage, "!characters") {
 		characters := GetCharacters(bot)
 		bot.Message("[character list] " + characters)
+
+	} else if strings.Contains(userMessage, "!moves") {
+		movesCmd := strings.Split(userMessage, "!moves")
+
+		bot.Log(strconv.Itoa(len(movesCmd)))
+
+		characterName := strings.ToLower(strings.TrimSpace(movesCmd[1]))
+		character := newCharacter(characterName, apiConfig.endpoint, bot)
+		message := character.PrintFormattedMoveList()
+
+		bot.Message(message)
 
 	} else {
 		bot.Message("Command not supported BibleThump")


### PR DESCRIPTION
Presents a link to the user containing the names of moves that can be queried against the fgframebot. Note that we present the user with a link to the move set vs. sending all moves to the user in chat in order circumvent the character limit. Addresses #1 
